### PR TITLE
GameObject -> BloonScript reference

### DIFF
--- a/Assets/ScriptTemplates.meta
+++ b/Assets/ScriptTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: deee3d4f7a5ea7f49a782a3f17331e18
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt
+++ b/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+    #ROOTNAMESPACEBEGIN#
+public class #SCRIPTNAME# : MonoBehaviour
+{
+    void Awake()
+    {
+        #NOTRIM#
+    }
+}
+#ROOTNAMESPACEEND#

--- a/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt
+++ b/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt
@@ -1,13 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
     #ROOTNAMESPACEBEGIN#
 public class #SCRIPTNAME# : MonoBehaviour
 {
-    void Awake()
-    {
-        #NOTRIM#
-    }
+    #NOTRIM#
 }
 #ROOTNAMESPACEEND#

--- a/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt.meta
+++ b/Assets/ScriptTemplates/81-C# Script__MonoBehaviour-MB.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c9c2cafc236e06944b16221f410a67eb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt
+++ b/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
     #ROOTNAMESPACEBEGIN#

--- a/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt
+++ b/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+    #ROOTNAMESPACEBEGIN#
+[CreateAssetMenu(menuName = AssetMenuConst.ScriptableObject + nameof(#SCRIPTNAME#))]
+public class #SCRIPTNAME# : ScriptableObject
+{
+    #NOTRIM#
+}
+#ROOTNAMESPACEEND#

--- a/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt.meta
+++ b/Assets/ScriptTemplates/81-C# Script__ScriptableObject-SO.cs.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 588f43a38a3e34a4288dce1eeb0617be
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AssetMenuConst.cs
+++ b/Assets/ScriptableObjects/AssetMenuConst.cs
@@ -1,0 +1,4 @@
+public class AssetMenuConst
+{
+    public const string ScriptableObject = nameof(ScriptableObject) + "/";
+}

--- a/Assets/ScriptableObjects/AssetMenuConst.cs.meta
+++ b/Assets/ScriptableObjects/AssetMenuConst.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51a711d56b971b046886f13770f7aa7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Bloons/BloonSO.cs
+++ b/Assets/ScriptableObjects/Bloons/BloonSO.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-[CreateAssetMenu(fileName = "bloon", menuName = "ScriptableObjects/Bloon")]
+[CreateAssetMenu(menuName = AssetMenuConst.ScriptableObject + nameof(BloonSO))]
 public class BloonSO : ScriptableObject
 {
     [System.Serializable]

--- a/Assets/Scripts/BloonSpawner.cs
+++ b/Assets/Scripts/BloonSpawner.cs
@@ -6,7 +6,7 @@ using UnityEngine.Splines;
 
 public class BloonSpawner : MonoBehaviour
 {
-    [SerializeField] GameObject bloonBase;
+    [SerializeField] BloonScript bloonBase;
 
     public List<BloonSO> nextWave = new();
     public List<float> delays = new();
@@ -48,8 +48,8 @@ public class BloonSpawner : MonoBehaviour
     private IEnumerator SpawnBloon(float spawnDelay)
     {
         yield return new WaitForSeconds(spawnDelay);
-        Instantiate(bloonBase);
-        var script = bloonBase.GetComponent<BloonScript>();
+
+        var script = Instantiate(bloonBase);
         script.spawnIndex = spawnIndex;
         script.bloonObject = nextWave[spawnIndex];
         script.path = tracks[0];


### PR DESCRIPTION
you can reference monobehaviours instead of gameobjects so you dont have to call get component (wich might not even be on it)